### PR TITLE
Patch/ap iref skin

### DIFF
--- a/src/pages/api/index.md
+++ b/src/pages/api/index.md
@@ -1,7 +1,6 @@
 ---
 title: Photoshop API Reference
 description: Photoshop API Reference
-openAPISpec:  /photoshop_api.json
 contributors:
   - https://github.com/khound
   - https://github.com/archyposada

--- a/src/pages/api/index.md
+++ b/src/pages/api/index.md
@@ -6,4 +6,4 @@ contributors:
   - https://github.com/archyposada
 ---
 
-<RedoclyAPIBlock src="/photoshop_api.json" scrollYOffset={64} generateCodeSamples="languages: [{lang: 'curl'}]" />
+<RedoclyAPIBlock src="/firefly-services/docs/photoshop/photoshop_api.json" scrollYOffset={64} generateCodeSamples="languages: [{lang: 'curl'}]" />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The `openAPIRef` frontmatter needed to be removed so that the Redocly skin is used in the build for the API reference page.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
