### PR TITLE
renamed schemas without photoroom for Remove Background v2

### DIFF
--- a/static/photoshop_api.json
+++ b/static/photoshop_api.json
@@ -275,7 +275,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/PhotoroomRemoveBackgroundRequest"
+                "$ref": "#/components/schemas/RemoveBackgroundV2Request"
               }
             }
           }
@@ -5854,7 +5854,7 @@
           "url"
         ]
       },
-      "PhotoroomRemoveBgInputImage": {
+      "RemoveBgInputImage": {
         "type": "object",
         "properties": {
           "source": {
@@ -5880,7 +5880,7 @@
           "psd"
         ]
       },
-      "PhotoroomRemoveBgOutputImageMediaType": {
+      "RemoveBgOutputImageMediaType": {
         "type": "string",
         "description": "The media type of the output image. By default this will match the input source file format.",
         "enum": [
@@ -5890,15 +5890,15 @@
           "image/vnd.adobe.photoshop"
         ]
       },
-      "PhotoroomRemoveBgOutputImageOptions": {
+      "RemoveBgOutputImageOptions": {
         "type": "object",
         "properties": {
           "mediaType": {
-            "$ref": "#/components/schemas/PhotoroomRemoveBgOutputImageMediaType"
+            "$ref": "#/components/schemas/RemoveBgOutputImageMediaType"
           }
         }
       },
-      "PhotoroomColor": {
+      "RemoveBgColor": {
         "type": "object",
         "properties": {
           "red": {
@@ -5933,14 +5933,14 @@
           "alpha"
         ]
       },
-      "PhotoroomRemoveBackgroundRequest": {
+      "RemoveBackgroundV2Request": {
         "type": "object",
         "properties": {
           "image": {
             "description": "The image to be processed.",
             "allOf": [
               {
-                "$ref": "#/components/schemas/PhotoroomRemoveBgInputImage"
+                "$ref": "#/components/schemas/RemoveBgInputImage"
               }
             ]
           },
@@ -5951,7 +5951,7 @@
             "description": "The options for the output image.",
             "allOf": [
               {
-                "$ref": "#/components/schemas/PhotoroomRemoveBgOutputImageOptions"
+                "$ref": "#/components/schemas/RemoveBgOutputImageOptions"
               }
             ]
           },
@@ -5964,7 +5964,7 @@
             "description": "The background color.",
             "allOf": [
               {
-                "$ref": "#/components/schemas/PhotoroomColor"
+                "$ref": "#/components/schemas/RemoveBgColor"
               }
             ]
           },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Renamed Remove Background schemas superficially to remove "Photoroom" references. This DOES NOT make the schemas match the internal API. Those schemas still need to be aligned with the internal Swagger for this ticket.

## Related Issue

https://jira.corp.adobe.com/browse/FFENT-1960

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
