### PR TITLE
chore- Symlink .cursor to ff-services-docs

### DIFF
--- a/.cursor
+++ b/.cursor
@@ -1,0 +1,1 @@
+../ff-services-docs/.cursor


### PR DESCRIPTION
# Summary
Replaces the tracked `.cursor` directory with a symlink to `../ff-services-docs/.cursor` so Cursor rules, skills, and agents stay aligned with the ff-services-docs source of truth.

# Changes

## `.cursor`
* Symlink to sibling repository `ff-services-docs` `.cursor` directory; remove duplicated tracked rule files.

# Context

## Jira
No ticket
