### PR TITLE
feat/FFENT-10621- Document Photoshop API v1 sunset announcement

### DIFF
--- a/src/pages/getting-started/deprecation-announcement/index.md
+++ b/src/pages/getting-started/deprecation-announcement/index.md
@@ -1,118 +1,53 @@
 ---
-title: Deprecation Announcement
-description: Learn about the deprecation of the Photoshop API.
+title: Deprecation Announcements in Photoshop API
+description: Learn about the deprecations happening in the Photoshop API.
 hideBreadcrumbNav: true
 keywords:
   - deprecation
   - photoshop api
+  - v1 deprecation
+  - v2 deprecation
 ---
+# V1 deprecation announcement
 
-# Deprecation announcement
+Photoshop API v1 will be reaching **end‑of‑life (EoL) in August of 2026**.
 
-The Remove Background V1 API (`/sensei/cutout`) and the Mask API (`/sensei/mask`) are being deprecated in favor of the Remove Background V2 API (`/v2/remove-background`).
+Customers currently relying on v1 endpoints are encouraged to begin planning their migration to Photoshop API v2, which is available in public beta and provides the following benefits:
 
-Remove Background V2 now supports both cutout and mask workflows through a single endpoint. The Remove Background V1 API and Mask API will reach End of Life (EOL) on *October 15, 2025*. After this date, they will no longer be supported or accessible.
-Please begin migration to Remove Background V2 as soon as possible to ensure uninterrupted service.
+* Modern, consistent API contracts
+* Improved scalability and reliability
+* A more extensible foundation for future workflows.
 
-For guidance about this change, refer to the FAQs below.
+Migrate to Photoshop API v2 before **August of 2026** to avoid service disruptions. For guidance about this change, refer to the FAQs below.
 
 <AccordionItem slots="heading, text" />
 
 ### What should I do?
 
-Migrate to the Remove Background V2 API before **October 15, 2025** to avoid service disruptions. \<br /\>  
-Remove Background V2 now handles both cutout and mask workflows using a single endpoint. To specify which operation you want, set the `"mode"` parameter in your request to `"cutout"` for background removal or `"mask"` for generating a mask. This allows a single API to support both workflows while ensuring consistent, high-quality results.
-
+Migrate to Photoshop API v2 before **August of 2026** to avoid service disruptions.
+  
 <AccordionItem slots="heading, text" />
 
 ### Why is Adobe making this change?
 
-We're moving to the Remove Background V2 API because it delivers: \<br /\> \<br /\> - Cleaner cutouts - The improved post-processing reduces matting and creates sharper edges. \<br /\> - Higher quality automation - Outputs with V2 are optimized for production pipelines and automated workflows.  \<br /\> - Ongoing support - V2 is the actively supported service that will receive updates and improvements.
+Photoshop API v1 was the first‑generation set of Firefly‑powered Photoshop APIs used by customers to automate Photoshop operations and imaging workflows. This version runs on legacy infrastructure and is being phased out as part of the transition to the modern Photoshop API v2 platform.
 
 <AccordionItem slots="heading, text" />
 
 ### When is this happening?
 
-Deprecation Notice: September 2, 2025. \<br /\>
-End of Life (EOL): October 15, 2025.
+Deprecation Notice: April 20, 2026. \<br /\>
+End of Life (EOL): August 31, 2026.
 
 <AccordionItem slots="heading, text" />
 
 ### Where can I find resources?
 
-The latest comprehensive [information about all Photoshop APIs is available on the API Reference page](https://developer.adobe.com/firefly-services/docs/photoshop/api/#operation/removeBackground). \<br /\> \<br /\>
-For technical details specifically about the Remove Background V2 API, refer to the Remove Background V2 endpoint.
+The latest comprehensive [information about all Photoshop APIs is available on the API Reference page](https://developer.adobe.com/firefly-services/docs/photoshop/api/photoshop-v2-beta/index.md). \<br /\> \<br /\>
+Migration guides for the Photoshop API v2 are available on the [Photoshop v2 beta guides page](/guides/photoshop-v2-beta/index.md).
 
 <AccordionItem slots="heading, text"/>
 
 ### Who can help me with migration?
 
 Your Adobe Customer Success Manager and Support Team are available to answer questions and guide you through the transition.
-
-<AccordionItem slots="heading, text, code" />
-
-### Can I see any newer example cutout request?
-
-**Cutout workflow**
-
-```shell
-curl -i -X POST \
-  https://image.adobe.io/v2/remove-background \
-  -H 'Authorization: string' \
-  -H 'Content-Type: application/json' \
-  -H 'x-api-key: YOUR_API_KEY_HERE' \
-  -d '{
-    "image": {
-      "source": {
-        "url": "string"
-      }
-    },
-    // Set "mode:" to "cutout" for background removal
-    "mode": "cutout",  
-    "output": {
-      "mediaType": "image/jpeg"
-    },
-    "trim": false,
-    "backgroundColor": {
-      "red": 255,
-      "green": 255,
-      "blue": 255,
-      "alpha": 1
-    },
-    "colorDecontamination": 1
-  }'
-```
-
-<AccordionItem slots="heading, text, code" />
-
-### Can I see a newer example mask request?
-
-**Mask workflow**
-
-```shell
-curl -i -X POST \
-  https://image.adobe.io/v2/remove-background \
-  -H 'Authorization: string' \
-  -H 'Content-Type: application/json' \
-  -H 'x-api-key: YOUR_API_KEY_HERE' \
-  -d '{
-    "image": {
-      "source": {
-        "url": "string"
-      }
-    },
-    // Set "mode:" to "mask" to generate a mask of the subject
-    "mode": "mask",  
-    "output": {
-      "mediaType": "image/png"
-    },
-    "trim": false,
-    "backgroundColor": {
-      "red": 255,
-      "green": 255,
-      "blue": 255,
-      "alpha": 1
-    },
-    "colorDecontamination": 1
-  }'
-```

--- a/static/photoshopv2-api.json
+++ b/static/photoshopv2-api.json
@@ -6,7 +6,7 @@
       "name": "Adobe Creative API License",
       "url": "https://www.adobe.com/content/dam/cc/en/legal/terms/enterprise/pdfs/PSLT-AdobeCreativeAPI-WW-2024v2.pdf"
     },
-    "title": "Photoshop v2 beta API endpoints",
+    "title": "Photoshop v2 API endpoints",
     "version": "beta"
   },
   "servers": [

--- a/static/photoshopv2-api.json
+++ b/static/photoshopv2-api.json
@@ -1,7 +1,7 @@
 {
   "openapi": "3.0.1",
   "info": {
-    "description": "Photoshop v2 beta API Server for Adobe DI Arts.",
+    "description": "Photoshop v2 API Server for Adobe DI Arts.",
     "license": {
       "name": "Adobe Creative API License",
       "url": "https://www.adobe.com/content/dam/cc/en/legal/terms/enterprise/pdfs/PSLT-AdobeCreativeAPI-WW-2024v2.pdf"


### PR DESCRIPTION
# Summary

Updates the deprecation announcement to communicate Photoshop API **v1** end-of-life (August 2026), encourages migration to Photoshop API **v2** (public beta), and refreshes FAQ copy, dates, and resource links. Aligns the OpenAPI `info.description` string in `photoshopv2-api.json` with the current product wording (removes “beta” from that server description line).

# Changes

## `src/pages/getting-started/deprecation-announcement/index.md`

* Refocus the page on API v1 sunset: EoL timing, migration to v2, benefits, deprecation notice and EOL dates, and links to the v2 API reference and beta guides.
* Remove Remove Background–specific FAQ content and long cURL examples.
* Adjust frontmatter title, description, and keywords for v1 deprecation.

## `static/photoshopv2-api.json`

* Update `info.description` to “Photoshop v2 API Server for Adobe DI Arts.” (drop “beta” from that string).

# Context

## Jira

[FFENT-10621](https://jira.corp.adobe.com/browse/FFENT-10621)
