### PR TITLE
granular labels

### DIFF
--- a/src/pages/guides/granular-labels/index.md
+++ b/src/pages/guides/granular-labels/index.md
@@ -1,0 +1,180 @@
+# Mask Body Parts API: Granular Labels
+
+**USAGE GUIDE • ADOBE FIREFLY PHOTOSHOP API • MASK BODY PARTS — GRANULAR LABELS**
+
+Feature Guide — `useGranularLabels` | API Version: v1 | April 2026
+
+---
+
+## 1. Overview
+
+The Mask Body Parts API (`/v1/mask-body-parts`) detects and segments human body parts and clothing items in images, returning individual mask images for each identified region. By default, bilateral body parts (those that appear on both sides of the body) are returned as a single combined mask.
+
+The granular labels feature extends this capability by returning side-specific masks for bilateral parts. When enabled, you receive separate, independent masks for the left and right instances of each applicable body part. This is controlled by the `useGranularLabels` boolean field in the request body.
+
+---
+
+## 2. When to Use Granular Labels
+
+Use `useGranularLabels: true` when your workflow requires:
+
+- **Independent per-limb compositing** — applying different shadow directions, reflections, or lighting effects to the left and right sides of a subject independently.
+- **Ground shadow generation** — grounding individual feet or shoes for realistic shadow placement in sports and retail imagery.
+- **Leg and foot reflection effects** — creating accurate mirror reflections for individual limbs without bleed from the opposite side.
+- **High-volume automation** — processing large batches of sports player or product images where manual mask splitting is not feasible.
+- **Precision apparel segmentation** — differentiating left/right sleeves, gloves, or shoes for e-commerce product presentation.
+
+> ⚠️ If your workflow treats both sides of the body identically (e.g., full-body background removal), you do not need granular labels. Omit the flag or set it to `false` to use the standard, combined label set with lower response payload size.
+
+---
+
+## 3. API Reference
+
+### Endpoint
+
+```
+POST https://image.adobe.io/v1/mask-body-parts
+```
+
+### Request Body Fields
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `image` | object | Yes | The input image object. Contains `source` (URL) and `mediaType` fields. |
+| `image.source.url` | string | Yes | Presigned URL of the input image. Max dimensions: 4000 x 4000 px. |
+| `image.mediaType` | string | Yes | Media type of the input image. Accepted: `image/jpeg`, `image/png`. |
+| `mask` | object | Yes | The subject mask object. Contains `source` (URL) and `mediaType` fields. |
+| `mask.source.url` | string | Yes | Presigned URL of the subject mask image. Must be `image/png`. |
+| `useGranularLabels` | boolean | No | When `true`, returns side-specific masks for bilateral body parts. Defaults to `false`. |
+
+---
+
+## 4. Request Examples
+
+### Standard Request (Granular Labels Disabled)
+
+```json
+{
+  "image": {
+    "source": { "url": "https://storage.example.com/athlete.png" },
+    "mediaType": "image/png"
+  },
+  "mask": {
+    "source": { "url": "https://storage.example.com/athlete_mask.png" },
+    "mediaType": "image/png"
+  }
+}
+```
+
+### Granular Labels Request
+
+```json
+{
+  "image": {
+    "source": { "url": "https://storage.example.com/athlete.png" },
+    "mediaType": "image/png"
+  },
+  "mask": {
+    "source": { "url": "https://storage.example.com/athlete_mask.png" },
+    "mediaType": "image/png"
+  },
+  "useGranularLabels": true
+}
+```
+
+---
+
+## 5. Response Structure
+
+The endpoint is asynchronous. The initial response is `202 Accepted` with a `jobId` and `statusUrl`. Poll the status endpoint until `status` is `succeeded`, then retrieve your `masks` array.
+
+### Polling Status
+
+```
+GET https://image.adobe.io/v1/status/{jobId}
+```
+
+### Succeeded Response (Granular Labels)
+
+```json
+{
+  "jobId": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+  "status": "succeeded",
+  "masks": [
+    {
+      "label": "Left Shoe",
+      "score": 0.97,
+      "boundingBox": { "left": 142, "top": 810, "width": 190, "height": 110 },
+      "destination": { "url": "https://storage.adobe.io/..." },
+      "mediaType": "image/png"
+    },
+    {
+      "label": "Right Shoe",
+      "score": 0.96,
+      "boundingBox": { "left": 352, "top": 812, "width": 188, "height": 108 },
+      "destination": { "url": "https://storage.adobe.io/..." },
+      "mediaType": "image/png"
+    },
+    {
+      "label": "Left Leg",
+      "score": 0.98,
+      "boundingBox": { "...": "..." },
+      "destination": { "url": "https://storage.adobe.io/..." },
+      "mediaType": "image/png"
+    },
+    { "label": "Right Leg", "...": "..." },
+    { "label": "Upper Clothes", "...": "..." }
+  ]
+}
+```
+
+---
+
+## 6. Granular Label Reference
+
+The following labels may be returned in the `masks` array when `useGranularLabels` is `true`. Labels that are not bilateral (e.g., Face, Hair, Upper Clothes) are returned identically in both standard and granular modes.
+
+| Body Region | Standard Labels | Granular Labels (New) |
+| --- | --- | --- |
+| Face / Head | Hair, Eyebrow, Eyes, Pupil, Nose, Mouth, Teeth, Face, Neck | Same (no change) |
+| Beard | Beard | Same (no change) |
+| Ears | Ear (combined) | **Left Ear, Right Ear** |
+| Arms | Arm (combined) | **Left Arm, Right Arm** |
+| Hands | Hand (combined) | **Left Hand, Right Hand** |
+| Legs | Leg (combined) | **Left Leg, Right Leg** |
+| Feet / Shoes | Feet / Shoe (combined) | **Left Shoe, Right Shoe** |
+| Upper Apparel | Upper Clothes | Same (no change) |
+| Lower Apparel | Lower Clothes | Same (no change) |
+| Outerwear | Coat | Same (no change) |
+| Dress | Dress | Same (no change) |
+| Hat | Hat | Same (no change) |
+| Glasses | Glasses | Same (no change) |
+| Accessories | Accessories | Same (no change) |
+| Background | Background | Same (no change) |
+
+---
+
+## 7. Best Practices
+
+- Only enable `useGranularLabels` when your workflow requires left/right differentiation. The standard mode returns a smaller payload and may process faster.
+- Ensure your input mask accurately covers the full subject. Poor subject masks may result in incomplete or merged left/right detections.
+- Store masks by label from the response array — do not assume a fixed ordering. Always read the `label` field to identify each mask.
+- For ground shadow workflows: use the `Left Shoe` and `Right Shoe` masks independently to calculate shadow anchor points per foot.
+- For reflection workflows: mirror each shoe or leg mask individually along the vertical axis to create correct per-limb reflections.
+- Input images should not exceed 4000 x 4000 px. For higher-resolution source images, downscale before calling the API.
+
+---
+
+## 8. Error Handling
+
+| HTTP Code | `error_code` | Meaning / Action |
+| --- | --- | --- |
+| 400 | `input_validation_error` | Malformed request body. Check required fields and data types. |
+| 401 | `unauthorized` | Missing or invalid bearer token. Re-authenticate. |
+| 403 | `forbidden` | Valid token but insufficient permissions. Verify API entitlements. |
+| 429 | `too_many_requests` | Rate limit exceeded. Implement exponential backoff. |
+| 500 | `internal_server_error` | Transient server error. Retry with backoff before escalating. |
+
+---
+
+*Adobe Firefly Photoshop API — Mask Body Parts Granular Labels Guide • April 2026 • v1*

--- a/static/photoshop_api.json
+++ b/static/photoshop_api.json
@@ -2211,8 +2211,8 @@
           "Masking"
         ],
         "operationId": "maskBodyParts",
-        "summary": "Generate human item masks",
-        "description": "This endpoint processes an input image of a human, then identifies and creates masks for various items and sections on the body including sunglasses, hats, upper body apparel, lower body apparel, left arm, right arm, and more. The API returns an array of masks corresponding to each detected item and body part. To check the status of this process, utilize the `Get Status - V1` endpoint.",
+        "summary": "Generate human body part masks (with optional granular labels)",
+        "description": "This endpoint processes an input image of a human, then identifies and creates masks for various items and sections on the body including sunglasses, hats, upper body apparel, lower body apparel, arms, legs, shoes, and more. The API returns an array of masks corresponding to each detected item and body part.\n\n**Granular Labels (New \u2014 GA):** Set `useGranularLabels: true` in the request body to receive side-specific masks for bilateral body parts. For example, instead of a single combined mask, the API returns separate masks for `Left Shoe` and `Right Shoe`, `Left Arm` and `Right Arm`, and so on. This capability is essential for workflows that apply independent effects \u2014 such as ground shadows or reflections \u2014 to individual limbs at scale.\n\nTo check the status of this process, utilize the `Get Status - V1` endpoint.",
         "x-ffs-async-job": true,
         "x-ffs-job-status-fetcher": "facadeJobStatus",
         "parameters": [],
@@ -6083,6 +6083,11 @@
                 "$ref": "#/components/schemas/MaskBodyPartsInputMask"
               }
             ]
+          },
+          "useGranularLabels": {
+            "type": "boolean",
+            "description": "When set to true, the API returns granular side-specific labels for bilateral body parts (e.g., Left Shoe, Right Shoe, Left Arm, Right Arm). When false or omitted, the API returns the default combined label set. See the Granular Labels section of the documentation for the full label reference.",
+            "default": false
           }
         },
         "required": [
@@ -6266,7 +6271,8 @@
         "properties": {
           "label": {
             "type": "string",
-            "description": "The label of the identified body part."
+            "description": "The label of the identified body part or item. When useGranularLabels is true, side-specific labels (e.g., Left Shoe, Right Shoe) are returned. See GranularBodyPartLabel for the full enumeration of possible values.",
+            "example": "Left Shoe"
           },
           "boundingBox": {
             "description": "The bounding box of the identified body part.",
@@ -6577,6 +6583,40 @@
         "required": [
           "jobId",
           "status"
+        ]
+      },
+      "GranularBodyPartLabel": {
+        "type": "string",
+        "description": "The set of body part labels returned when useGranularLabels is true.",
+        "enum": [
+          "Background",
+          "Hair",
+          "Eyebrow",
+          "Eyes",
+          "Pupil",
+          "Nose",
+          "Mouth",
+          "Teeth",
+          "Face",
+          "Neck",
+          "Beard",
+          "Left Ear",
+          "Right Ear",
+          "Left Arm",
+          "Right Arm",
+          "Left Hand",
+          "Right Hand",
+          "Left Leg",
+          "Right Leg",
+          "Left Shoe",
+          "Right Shoe",
+          "Upper Clothes",
+          "Lower Clothes",
+          "Coat",
+          "Dress",
+          "Hat",
+          "Glasses",
+          "Accessories"
         ]
       }
     },


### PR DESCRIPTION
- **The changes are a mix of things — removing split-view and side-by-side entries from the nav and migration table, adding a smart object row to the v1→v2 mapping table, a minor copy fix in the smart objects guide, and two fixes in the OpenAPI spec (branding rename + consolidating security requirements)**
- **added granular labels guide and updated Mask Body schema to include new param for labels**

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
