### PR TITLE
feat/FFENT-12856- Add AutoCrop GA guide and API reference

### DIFF
--- a/src/pages/config.md
+++ b/src/pages/config.md
@@ -43,7 +43,7 @@
       - [Smart Object workflow](/guides/photoshop-v2/v1-to-v2/guides-v2/smart-object-workflow.md)
       - [v2/edit API benchmarking](/guides/photoshop-v2/v1-to-v2/guides-v2/v2-edit-api-benchmarking.md)
       - [Pegasus worker v2 model reference](/guides/photoshop-v2/v1-to-v2/guides-v2/pegasus-worker-v2-models.md)
-      - [Autocrop feature guide](/guides/autocrop/index.md)
+      - [AutoCrop feature guide](/guides/autocrop/index.md)
     - [Photoshop API v1 guides](/guides/v1/index.md)
       - [Granular Labels](/guides/granular-labels/index.md)
       - [Photoshop Actions](/guides/photoshop-actions/index.md)

--- a/src/pages/config.md
+++ b/src/pages/config.md
@@ -43,6 +43,7 @@
       - [Smart Object workflow](/guides/photoshop-v2/v1-to-v2/guides-v2/smart-object-workflow.md)
       - [v2/edit API benchmarking](/guides/photoshop-v2/v1-to-v2/guides-v2/v2-edit-api-benchmarking.md)
       - [Pegasus worker v2 model reference](/guides/photoshop-v2/v1-to-v2/guides-v2/pegasus-worker-v2-models.md)
+      - [Autocrop feature guide](/guides/autocrop/index.md)
     - [Photoshop API v1 guides](/guides/v1/index.md)
       - [Granular Labels](/guides/granular-labels/index.md)
       - [Photoshop Actions](/guides/photoshop-actions/index.md)

--- a/src/pages/contributors.json
+++ b/src/pages/contributors.json
@@ -1,7 +1,7 @@
 {
-  "total": 71,
+  "total": 72,
   "offset": 0,
-  "limit": 71,
+  "limit": 72,
   "data": [
     {
       "page": "/",
@@ -10,7 +10,7 @@
         "https://avatars.githubusercontent.com/u/48109457?v=4",
         "https://avatars.githubusercontent.com/u/41382203?v=4"
       ],
-      "lastUpdated": "5/12/2026"
+      "lastUpdated": "6/16/2026"
     },
     {
       "page": "/api/",
@@ -36,7 +36,7 @@
         "https://avatars.githubusercontent.com/u/48109457?v=4",
         "https://avatars.githubusercontent.com/u/41382203?v=4"
       ],
-      "lastUpdated": "5/12/2026"
+      "lastUpdated": "6/16/2026"
     },
     {
       "page": "/getting-started/",
@@ -115,6 +115,13 @@
         "https://avatars.githubusercontent.com/u/195011431?v=4"
       ],
       "lastUpdated": "5/6/2026"
+    },
+    {
+      "page": "/guides/autocrop/",
+      "avatars": [
+        "https://avatars.githubusercontent.com/u/195011431?v=4"
+      ],
+      "lastUpdated": "6/16/2026"
     },
     {
       "page": "/guides/create-mask/",

--- a/src/pages/guides/autocrop/index.md
+++ b/src/pages/guides/autocrop/index.md
@@ -1,0 +1,55 @@
+---
+title: AutoCrop API Feature Guide
+description: Learn how Firefly's AutoCrop API automatically generates aesthetically pleasing and contextually relevant crops for images and video thumbnails.
+hideBreadcrumbNav: true
+keywords:
+  - autocrop
+  - smart crop
+  - automatic cropping
+  - subject detection
+  - priority object crop
+  - super box crop
+  - video thumbnails
+contributors:
+  - https://github.com/AEAbreu-hub
+---
+
+# AutoCrop
+
+Perform automatic cropping on images or video thumbnails.
+
+## What is AutoCrop API?
+
+Firefly's AutoCrop API is a smart cropping service that automatically generates aesthetically pleasing and contextually relevant crops and resizing of images or video thumbnails. It leverages deep learning models to detect and preserve key foreground objects.
+
+The service is designed to support these key scenarios:
+
+### Smart crop
+
+Given an image and a target resolution, the service returns an optimal crop.
+
+* Automatically detects and preserves the main subject(s) of the image.
+* Generates a visually balanced crop tailored to the target aspect ratio.
+* Ideal for thumbnails, banners, or platform-specific aspect ratios.
+
+### Priority object crop
+
+Given an image, a target resolution, and a list of objects, the service returns a crop that prioritizes these objects.
+
+* Performs object detection and reorders cropping logic based on the specified list.
+* Higher-priority objects are more likely to be included in the crop.
+* Best for editorial workflows or product-centric cropping.
+
+### Full subject crop
+
+Given an image, the service returns the minimum bounding crop that contains all detected foreground objects.
+
+* Ignores aspect ratio constraints to generate a tight fit around all relevant content.
+* Primarily used for hero shots or full-scene object framing, or as a fallback if the aspect-ratio crop isn't feasible.
+
+### Object detection and Super Box crop
+
+Given an image, the service returns bounding boxes for all detected objects, and a subject crop—a "Super Box" that encloses all detected objects.
+
+* Enables downstream workflows like tagging, reflow design, and variant generation.
+* The Super Box may optionally be used as a crop where context retention is more important than aspect ratio.

--- a/src/pages/index.md
+++ b/src/pages/index.md
@@ -128,6 +128,7 @@ Many useful Photoshop operations are available in the v2 API. Here are just a fe
 - **[Smart Objects](/guides/smart-objects-and-the-api/index.md)** — Create and replace embedded and linked Smart Objects in a PSD so new imagery fits the original layer bounds and keeps its aspect ratio.
 - **[Product Crop](/guides/product-crop/index.md)** — Smart-crop images by detecting the subject and framing it as the focal point.
 - **[ActionJSON](/guides/actionjson-endpoint/index.md)** — Apply Photoshop Actions from an ATN file programmatically and adjust the action payload for more flexible, dynamic edits.
+- **[Autocrop](/guides/autocrop/index.md)** — Auto-crop images by detecting the subject and framing it as the focal point.
 
 Explore all available services in the [Photoshop API v2 guides](/guides/photoshop-v2/index.md) or browse endpoints in the [Photoshop API v2 reference](/api/photoshop-v2/index.md).
 

--- a/static/photoshopv2-api.json
+++ b/static/photoshopv2-api.json
@@ -27,6 +27,112 @@
     }
   ],
   "paths": {
+    "/v1/auto-crop": {
+      "post": {
+        "description": "Generates smart crops, subject bounding boxes, and detects objects for an input image. The request is processed asynchronously. Poll GET /v2/status/{jobId} with the returned jobId for completion.",
+        "operationId": "autoCrop",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AutoCropRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "202": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JobAcceptedResponse"
+                }
+              }
+            },
+            "description": "Job accepted for processing"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Bad request - Invalid request payload"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Unauthorized - Invalid or missing access token"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Forbidden - User not authorized or quota exhausted"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Not found - Requested resource was not found"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Validation error - Invalid input data"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Too many requests - Rate limit exceeded. When present, Retry-After header (seconds) indicates delay before retrying."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Internal server error"
+          }
+        },
+        "servers": [
+          {
+            "description": "Production server.",
+            "url": "https://image.adobe.io"
+          }
+        ],
+        "summary": "Auto crop",
+        "tags": ["Photoshop APIs"]
+      }
+    },
     "/v2/create-artboard": {
       "post": {
         "operationId": "createArtboard",
@@ -458,7 +564,7 @@
     },
     "/v2/status/{jobId}": {
       "get": {
-        "description": "Retrieves the current status and details of a specific job including metadata, outputs, and processing information",
+        "description": "Retrieves the current status and details of a specific job including metadata, outputs, and processing information. Use this endpoint to poll jobs submitted to Photoshop v2 operations and POST /v1/auto-crop.",
         "operationId": "getJobStatus",
         "parameters": [
           {
@@ -1309,6 +1415,208 @@
           }
         },
         "description": "Auto straighten configuration with options"
+      },
+      "AutoCropAspectRatio": {
+        "type": "string",
+        "description": "Desired aspect ratio for generated crops.",
+        "enum": [
+          "1:1",
+          "16:9",
+          "9:16",
+          "4:3",
+          "3:4",
+          "4:5",
+          "5:4",
+          "3:2",
+          "2:3",
+          "21:9"
+        ]
+      },
+      "AutoCropBoundingBox": {
+        "required": ["x", "y", "width", "height"],
+        "type": "object",
+        "properties": {
+          "height": {
+            "type": "number",
+            "description": "Height of the bounding box."
+          },
+          "url": {
+            "type": "string",
+            "description": "Presigned URL for the cropped image. Only present when outputType is 'images'."
+          },
+          "width": {
+            "type": "number",
+            "description": "Width of the bounding box."
+          },
+          "x": {
+            "type": "number",
+            "description": "X coordinate of the bounding box."
+          },
+          "y": {
+            "type": "number",
+            "description": "Y coordinate of the bounding box."
+          }
+        }
+      },
+      "AutoCropCrop": {
+        "required": ["boundingBoxes"],
+        "type": "object",
+        "properties": {
+          "boundingBoxes": {
+            "type": "array",
+            "description": "List of bounding boxes for the generated crop.",
+            "items": {
+              "$ref": "#/components/schemas/AutoCropBoundingBox"
+            }
+          }
+        }
+      },
+      "AutoCropImageMediaType": {
+        "type": "string",
+        "description": "The media type of the input image. Supported values are image/jpeg, image/png, and image/webp.",
+        "enum": ["image/jpeg", "image/png", "image/webp"]
+      },
+      "AutoCropInputImage": {
+        "required": ["source"],
+        "type": "object",
+        "properties": {
+          "mediaType": {
+            "$ref": "#/components/schemas/AutoCropImageMediaType"
+          },
+          "source": {
+            "$ref": "#/components/schemas/AutoCropUrlResource"
+          }
+        },
+        "description": "The input image for the auto-crop operation."
+      },
+      "AutoCropMode": {
+        "type": "string",
+        "description": "Mode for the auto crop operation. 'smartCrop' and 'subjectCrop' generate crops using aspectRatio with optional zoom. 'fullSceneDetection' and 'objectDetection' detect subjects or objects in the scene.",
+        "enum": [
+          "smartCrop",
+          "subjectCrop",
+          "fullSceneDetection",
+          "objectDetection"
+        ]
+      },
+      "AutoCropObjectDetection": {
+        "required": ["objectName", "boundingBoxes", "confidence"],
+        "type": "object",
+        "properties": {
+          "boundingBoxes": {
+            "type": "array",
+            "description": "Bounding boxes enclosing the detected object in {x, y, width, height} format.",
+            "items": {
+              "$ref": "#/components/schemas/AutoCropBoundingBox"
+            }
+          },
+          "confidence": {
+            "type": "number",
+            "description": "Confidence score for the detected object."
+          },
+          "objectName": {
+            "type": "string",
+            "description": "Name of the detected object."
+          }
+        }
+      },
+      "AutoCropOutput": {
+        "required": ["subject", "objects", "crops"],
+        "type": "object",
+        "properties": {
+          "crops": {
+            "type": "array",
+            "description": "Generated crops for the input image.",
+            "items": {
+              "$ref": "#/components/schemas/AutoCropCrop"
+            }
+          },
+          "objects": {
+            "type": "array",
+            "description": "Detected objects in the input image.",
+            "items": {
+              "$ref": "#/components/schemas/AutoCropObjectDetection"
+            }
+          },
+          "subject": {
+            "type": "array",
+            "description": "Subject crops detected in the input image.",
+            "items": {
+              "$ref": "#/components/schemas/AutoCropCrop"
+            }
+          }
+        },
+        "description": "Auto crop output details."
+      },
+      "AutoCropOutputType": {
+        "type": "string",
+        "description": "Output type for the auto crop operation. 'images' returns cropped images with presigned URLs (default). 'boundingBoxes' returns only bounding box coordinates.",
+        "default": "images",
+        "enum": ["images", "boundingBoxes"]
+      },
+      "AutoCropRequest": {
+        "required": ["image", "mode"],
+        "type": "object",
+        "properties": {
+          "aspectRatio": {
+            "description": "Desired aspect ratio(s) for generated crops. Accepts either a single enum string or an array of up to 20 strings. Allowed only for 'smartCrop' and 'subjectCrop'. When omitted, the service defaults to 1:1. An empty array is treated as absent.",
+            "example": ["16:9", "1:1", "4:3"],
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/AutoCropAspectRatio"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/AutoCropAspectRatio"
+                }
+              }
+            ]
+          },
+          "focus": {
+            "type": "array",
+            "description": "Focus labels, ordered by preference, used to prioritize objects during cropping or as detection targets. Required for 'subjectCrop' and 'objectDetection'; must be empty for 'smartCrop' and 'fullSceneDetection'.",
+            "example": ["logo", "person"],
+            "items": {
+              "type": "string"
+            }
+          },
+          "image": {
+            "$ref": "#/components/schemas/AutoCropInputImage"
+          },
+          "mode": {
+            "$ref": "#/components/schemas/AutoCropMode"
+          },
+          "outputType": {
+            "$ref": "#/components/schemas/AutoCropOutputType"
+          },
+          "zoom": {
+            "description": "Optional zoom level(s) paired with aspectRatio. Accepts either a number or an array of up to 20 numbers in (0, 1]. Must not be sent without aspectRatio. When aspectRatio is an array, zoom may be omitted or must be a matching non-empty array.",
+            "example": [0.9, 0.8, 0.85],
+            "oneOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "type": "number"
+                }
+              }
+            ]
+          }
+        }
+      },
+      "AutoCropUrlResource": {
+        "required": ["url"],
+        "type": "object",
+        "properties": {
+          "url": {
+            "type": "string",
+            "description": "The URL of the resource. Only allow-listed domains are accepted as input URLs (e.g. amazonaws.com, windows.net, dropboxusercontent.com, assets.frame.io, storage.googleapis.com, adobe.io, azureedge.net, smartcreatives.stg.walmart.com)."
+          }
+        },
+        "description": "The source of the input image."
       },
       "BaseAdjustment": {
         "required": ["type"],


### PR DESCRIPTION
# Summary
Documents the AutoCrop API for GA: a feature guide covering smart crop, priority object crop, full subject crop, and Super Box detection scenarios, plus OpenAPI reference for POST /v1/auto-crop with v2 status polling.

# Changes

## `src/pages/guides/autocrop/index.md`
* Adds the AutoCrop feature guide with GA overview and descriptions of smart crop, priority object crop, full subject crop, and object detection and Super Box crop modes.

## `src/pages/config.md`
* Registers the Autocrop feature guide under Photoshop API v2 guides in site navigation.

## `src/pages/index.md`
* Links to the Autocrop feature guide from the Photoshop API overview page.

## `static/photoshopv2-api.json`
* Adds POST /v1/auto-crop with AutoCrop request and output schemas.
* Documents polling auto-crop jobs via the existing GET /v2/status/{jobId} endpoint.

# Context

## Jira
[FFENT-12856](https://jira.corp.adobe.com/browse/FFENT-12856)

Made with [Cursor](https://cursor.com)